### PR TITLE
Use bulk insert for shc to handle possible conflicts with manually added records.

### DIFF
--- a/FHICORC.Backend/FHICORC.Domain.Models/VaccineCodesModel.cs
+++ b/FHICORC.Backend/FHICORC.Domain.Models/VaccineCodesModel.cs
@@ -23,7 +23,8 @@ namespace FHICORC.Domain.Models
 
         [Column(TypeName = "varchar(1000)")]
         public string Target { get; set; }
-        
+
+        [Column(TypeName = "boolean")]
         public bool IsAddManually { get; set; }
     }
 }

--- a/FHICORC.Backend/FHICORC.Infrastructure.Database/Context/CoronapassContext.cs
+++ b/FHICORC.Backend/FHICORC.Infrastructure.Database/Context/CoronapassContext.cs
@@ -35,10 +35,6 @@ namespace FHICORC.Infrastructure.Database.Context
             modelBuilder
                 .Entity<VaccineCodesModel>()
                 .HasKey(k => new {k.VaccineCode, k.CodingSystem});
-            
-            modelBuilder
-                .Entity<VaccineCodesModel>()
-                .Property(k => k.IsAddManually).HasDefaultValue(true);
 
             base.OnModelCreating(modelBuilder);
         }


### PR DESCRIPTION
* Update vaccine info to not set default manually added each time.
* Issuer update name if conflicts.