### PR TITLE
Add endpoint for trusting/distrusting issuer in SHC.

### DIFF
--- a/FHICORC.Backend/FHICORC.Application.Models/SmartHealthCard/ShcTrustRequestDto.cs
+++ b/FHICORC.Backend/FHICORC.Application.Models/SmartHealthCard/ShcTrustRequestDto.cs
@@ -9,6 +9,6 @@ namespace FHICORC.Application.Models.SmartHealthCard
         [FromHeader]
         [Required]
         [JsonPropertyName("iss")]
-        public string iss { get; set; }
+        public string Iss { get; set; }
     }
 }

--- a/FHICORC.Backend/FHICORC.Application.Repositories/Interfaces/ITrustedIssuerRepository.cs
+++ b/FHICORC.Backend/FHICORC.Application.Repositories/Interfaces/ITrustedIssuerRepository.cs
@@ -10,8 +10,8 @@ namespace FHICORC.Application.Repositories.Interfaces
         Task AddIssuer(TrustedIssuerModel trustedIssuerModel);
         Task AddIssuers(IEnumerable<TrustedIssuerModel> trustedIssuerList);
         Task ReplaceAutomaticallyAddedIssuers(IEnumerable<TrustedIssuerModel> trustedIssuerList);
+        bool UpdateIsTrusted(string iss, bool trusted);
         Task<bool> CleanTable(bool keepIsAddManually);
         Task<bool> RemoveIssuer(string iss);
-        Task<bool> MarkAsUntrusted(string iss);
     }
 }

--- a/FHICORC.Backend/FHICORC.Application.Repositories/VaccineCodesRepository.cs
+++ b/FHICORC.Backend/FHICORC.Application.Repositories/VaccineCodesRepository.cs
@@ -66,7 +66,6 @@ namespace FHICORC.Application.Repositories
         public async Task AddVaccineCode(IEnumerable<VaccineCodesModel> vaccineCodesModel)
         {
             _coronapassContext.VaccineCodesModels.AddRange(vaccineCodesModel);
-            _coronapassContext.SaveChanges();
             await _coronapassContext.SaveChangesAsync();
         }
 
@@ -76,9 +75,7 @@ namespace FHICORC.Application.Repositories
             {
                 IQueryable<VaccineCodesModel> all;
                 all = onlyAuto ? _coronapassContext.VaccineCodesModels.Where(c => c.IsAddManually == false) : _coronapassContext.VaccineCodesModels;
-
                 _coronapassContext.VaccineCodesModels.RemoveRange(all);
-                _coronapassContext.SaveChanges();
                 await _coronapassContext.SaveChangesAsync();
                 return true;
             }

--- a/FHICORC.Backend/FHICORC.Application.Services/Interfaces/ITrustedIssuerService.cs
+++ b/FHICORC.Backend/FHICORC.Application.Services/Interfaces/ITrustedIssuerService.cs
@@ -9,8 +9,8 @@ namespace FHICORC.Application.Services.Interfaces
         public TrustedIssuerModel GetIssuer(string iss);
         public Task AddIssuers(AddIssuersRequest issuers, bool isAddManually);
         public Task ReplaceAutomaticallyAddedIssuers(ShcIssuersDto issuers);
+        public bool UpdateIsTrusted(string iss, bool trusted);
         public Task<bool> RemoveIssuer(string iss);
-        public Task<bool> MarkAsUntrusted(string iss);
         public Task<bool> RemoveAllIssuers(bool keepIsAddManually = false);
     }
 }

--- a/FHICORC.Backend/FHICORC.Application.Services/TrustedIssuerService.cs
+++ b/FHICORC.Backend/FHICORC.Application.Services/TrustedIssuerService.cs
@@ -46,7 +46,7 @@ namespace FHICORC.Application.Services
                 Name = x.name,
                 Iss = x.issuer,
                 IsAddManually = isAddManually,
-                IsMarkedUntrusted = false
+                IsTrusted = true
             });
             await _trustedIssuerRepository.AddIssuers(trustedIssuers);
         }
@@ -58,9 +58,14 @@ namespace FHICORC.Application.Services
                 Name = x.Name,
                 Iss = x.Iss,
                 IsAddManually = false,
-                IsMarkedUntrusted = false
+                IsTrusted = true
             });
             await _trustedIssuerRepository.ReplaceAutomaticallyAddedIssuers(trustedIssuers);
+        }
+
+        public bool UpdateIsTrusted(string iss, bool trusted)
+        {
+            return _trustedIssuerRepository.UpdateIsTrusted(iss, trusted);
         }
 
         public async Task<bool> RemoveIssuer(string iss)
@@ -73,20 +78,6 @@ namespace FHICORC.Application.Services
             catch (Exception ex)
             {
                 _logger.LogError("Remove Issuer" + ex.Message);
-                return false;
-            }
-        }
-
-        public async Task<bool> MarkAsUntrusted(string iss)
-        {
-            try
-            {
-                bool res = await _trustedIssuerRepository.MarkAsUntrusted(iss);
-                return res;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError("Issuer Marked" + ex.Message);
                 return false;
             }
         }

--- a/FHICORC.Backend/FHICORC.Domain.Models/TrustedIssuerModel.cs
+++ b/FHICORC.Backend/FHICORC.Domain.Models/TrustedIssuerModel.cs
@@ -16,6 +16,6 @@ namespace FHICORC.Domain.Models
         public bool IsAddManually { get; set; }
         
         [Column(TypeName = "boolean")]
-        public bool IsMarkedUntrusted { get; set; }
+        public bool IsTrusted { get; set; }
     }
 }

--- a/FHICORC.Backend/FHICORC.Infrastructure.Database/Migrations/20220118145939_TrustedIssuer.Designer.cs
+++ b/FHICORC.Backend/FHICORC.Infrastructure.Database/Migrations/20220118145939_TrustedIssuer.Designer.cs
@@ -111,7 +111,7 @@ namespace FHICORC.Infrastructure.Database.Migrations
                     b.Property<bool>("IsAddManually")
                         .HasColumnType("boolean");
 
-                    b.Property<bool>("IsMarkedUntrusted")
+                    b.Property<bool>("IsTrusted")
                         .HasColumnType("boolean");
 
                     b.Property<string>("Name")

--- a/FHICORC.Backend/FHICORC.Infrastructure.Database/Migrations/20220118145939_TrustedIssuer.cs
+++ b/FHICORC.Backend/FHICORC.Infrastructure.Database/Migrations/20220118145939_TrustedIssuer.cs
@@ -18,7 +18,7 @@ namespace FHICORC.Infrastructure.Database.Migrations
                     Iss = table.Column<string>(type: "varchar(5000)", nullable: false),
                     Name = table.Column<string>(type: "varchar(5000)", nullable: true),
                     IsAddManually = table.Column<bool>(type: "boolean", nullable: false),
-                    IsMarkedUntrusted = table.Column<bool>(type: "boolean", nullable: false)
+                    IsTrusted = table.Column<bool>(type: "boolean", nullable: false)
                 },
                 constraints: table =>
                 {

--- a/FHICORC.Backend/FHICORC.Infrastructure.Database/Migrations/20220121100201_CodingSystems.Designer.cs
+++ b/FHICORC.Backend/FHICORC.Infrastructure.Database/Migrations/20220121100201_CodingSystems.Designer.cs
@@ -111,7 +111,7 @@ namespace FHICORC.Infrastructure.Database.Migrations
                     b.Property<bool>("IsAddManually")
                         .HasColumnType("boolean");
 
-                    b.Property<bool>("IsMarkedUntrusted")
+                    b.Property<bool>("IsTrusted")
                         .HasColumnType("boolean");
 
                     b.Property<string>("Name")

--- a/FHICORC.Backend/FHICORC.Infrastructure.Database/Migrations/CoronapassContextModelSnapshot.cs
+++ b/FHICORC.Backend/FHICORC.Infrastructure.Database/Migrations/CoronapassContextModelSnapshot.cs
@@ -109,7 +109,7 @@ namespace FHICORC.Infrastructure.Database.Migrations
                     b.Property<bool>("IsAddManually")
                         .HasColumnType("boolean");
 
-                    b.Property<bool>("IsMarkedUntrusted")
+                    b.Property<bool>("IsTrusted")
                         .HasColumnType("boolean");
 
                     b.Property<string>("Name")


### PR DESCRIPTION
* Update database flag to be trusted and use this when retuning in get api
* Set default trusted to true for all create functions
* Dont replace distrusted rows on updating through job.
* Make single function for parsing http body in shc controller.